### PR TITLE
Add migrations for document and custom field tables

### DIFF
--- a/app/Models/Council.php
+++ b/app/Models/Council.php
@@ -3,6 +3,11 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use App\Models\Document;
+use App\Models\CustomFieldValue;
+use App\Models\FinancialYear;
 
 /**
  * Basic Council model storing key finance fields.
@@ -47,4 +52,20 @@ class Council extends Model
         'debt_adjustments' => 'array',
         'council_closed' => 'boolean',
     ];
+
+    public function documents(): HasMany
+    {
+        return $this->hasMany(Document::class);
+    }
+
+    public function customFieldValues(): HasMany
+    {
+        return $this->hasMany(CustomFieldValue::class);
+    }
+
+    public function financialYears(): BelongsToMany
+    {
+        return $this->belongsToMany(FinancialYear::class, 'council_financial_year')
+            ->withPivot('is_default');
+    }
 }

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\CustomFieldValue;
+
+class CustomField extends Model
+{
+    protected $fillable = [
+        'name',
+        'label',
+        'type',
+        'required',
+    ];
+
+    public function values(): HasMany
+    {
+        return $this->hasMany(CustomFieldValue::class);
+    }
+}

--- a/app/Models/CustomFieldValue.php
+++ b/app/Models/CustomFieldValue.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Council;
+use App\Models\CustomField;
+use App\Models\FinancialYear;
+
+class CustomFieldValue extends Model
+{
+    protected $fillable = [
+        'council_id',
+        'custom_field_id',
+        'financial_year_id',
+        'value',
+    ];
+
+    public function council(): BelongsTo
+    {
+        return $this->belongsTo(Council::class);
+    }
+
+    public function field(): BelongsTo
+    {
+        return $this->belongsTo(CustomField::class, 'custom_field_id');
+    }
+
+    public function financialYear(): BelongsTo
+    {
+        return $this->belongsTo(FinancialYear::class);
+    }
+}

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Council;
+use App\Models\FinancialYear;
+
+class Document extends Model
+{
+    protected $fillable = [
+        'filename',
+        'doc_type',
+        'council_id',
+        'financial_year_id',
+    ];
+
+    public function council(): BelongsTo
+    {
+        return $this->belongsTo(Council::class);
+    }
+
+    public function financialYear(): BelongsTo
+    {
+        return $this->belongsTo(FinancialYear::class);
+    }
+}

--- a/app/Models/FinancialYear.php
+++ b/app/Models/FinancialYear.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\Council;
+use App\Models\Document;
+use App\Models\CustomFieldValue;
+
+class FinancialYear extends Model
+{
+    protected $fillable = [
+        'year',
+        'is_default',
+    ];
+
+    public function councils(): BelongsToMany
+    {
+        return $this->belongsToMany(Council::class, 'council_financial_year')
+            ->withPivot('is_default');
+    }
+
+    public function documents(): HasMany
+    {
+        return $this->hasMany(Document::class);
+    }
+
+    public function fieldValues(): HasMany
+    {
+        return $this->hasMany(CustomFieldValue::class);
+    }
+}

--- a/database/migrations/2025_06_30_133426_create_documents_table.php
+++ b/database/migrations/2025_06_30_133426_create_documents_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('documents', function (Blueprint $table) {
+            $table->id();
+            $table->string('filename')->unique();
+            $table->string('doc_type');
+            $table->foreignId('council_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('financial_year_id')->constrained('financial_years');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('documents');
+    }
+};

--- a/database/migrations/2025_06_30_133428_create_custom_fields_table.php
+++ b/database/migrations/2025_06_30_133428_create_custom_fields_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('custom_fields', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('label');
+            $table->string('type');
+            $table->boolean('required')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('custom_fields');
+    }
+};

--- a/database/migrations/2025_06_30_133431_create_custom_field_values_table.php
+++ b/database/migrations/2025_06_30_133431_create_custom_field_values_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('custom_field_values', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('council_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('custom_field_id')->constrained('custom_fields')->cascadeOnDelete();
+            $table->foreignId('financial_year_id')->constrained('financial_years');
+            $table->longText('value')->nullable();
+            $table->timestamps();
+
+            $table->index('financial_year_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('custom_field_values');
+    }
+};

--- a/database/migrations/2025_06_30_133435_create_financial_years_table.php
+++ b/database/migrations/2025_06_30_133435_create_financial_years_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('financial_years', function (Blueprint $table) {
+            $table->id();
+            $table->string('year')->unique();
+            $table->boolean('is_default')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('financial_years');
+    }
+};

--- a/database/migrations/2025_06_30_133437_create_council_financial_year_table.php
+++ b/database/migrations/2025_06_30_133437_create_council_financial_year_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('council_financial_year', function (Blueprint $table) {
+            $table->foreignId('council_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('financial_year_id')->constrained('financial_years');
+            $table->boolean('is_default')->default(false);
+
+            $table->primary(['council_id', 'financial_year_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('council_financial_year');
+    }
+};


### PR DESCRIPTION
## Summary
- add Eloquent models for document and custom field storage
- create migrations for custom fields, field values, financial years and documents
- wire up new relations on `Council`

## Testing
- `vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_686291c2a1748331b70863dc11a35880